### PR TITLE
Fixes + allocate before experiment

### DIFF
--- a/jitter/Makefile
+++ b/jitter/Makefile
@@ -1,17 +1,20 @@
 FLAGS=-std=c++11
 
-all: exp1 main exp-endless main-endless
+all: exp1.o main.o exp-endless.o main-endless.o
 	${CXX} ${FLAGS} main.o exp1.o -o main
 	${CXX} ${FLAGS} main-endless.o exp-endless.o -o main-endless
 
-main: 
+main.o: 
 	${CXX} ${FLAGS} -c main.cpp 
 
-exp1: 
+exp1.o: 
 	${CXX} ${FLAGS} -c exp1.cpp 
 
-main-endless:
+main-endless.o:
 	${CXX} ${FLAGS} -c main-endless.cpp 
 
-exp-endless:
+exp-endless.o:
 	${CXX} ${FLAGS} -c exp-endless.cpp
+
+clean:
+	rm -f *.o main main-endless

--- a/jitter/exp-endless.cpp
+++ b/jitter/exp-endless.cpp
@@ -1,25 +1,11 @@
 #include <iostream>
 #include <vector>
 #include <cstdint>
-
+#include "exp.hpp"
 
 using namespace std;
 
-__attribute__((noinline))
-void task(int iterations) {
-  volatile int i = 0;
-  while(i < iterations) i++;
-}
-
-inline uint64_t cycles() noexcept {
-  uint32_t hi, lo;
-  asm("rdtsc" : "=a"(lo), "=d"(hi));
-  return ((uint64_t) lo) | ((uint64_t) hi) << 32;
-}
-
-
 int experiment(int task_size = 1000, int log_threshold = 1000) {
-  
   
   // Execute task_count tasks of task_size  
   while (true) {

--- a/jitter/exp.hpp
+++ b/jitter/exp.hpp
@@ -1,0 +1,12 @@
+
+__attribute__((noinline))
+void task(int iterations) {
+  volatile int i = 0;
+  while(i < iterations) i++;
+}
+
+inline uint64_t cycles() noexcept {
+  uint32_t hi, lo;
+  asm("rdtscp" : "=a"(lo), "=d"(hi));
+  return ((uint64_t) lo) | ((uint64_t) hi) << 32;
+}

--- a/jitter/exp1.cpp
+++ b/jitter/exp1.cpp
@@ -19,18 +19,17 @@ inline uint64_t cycles() noexcept {
 
 std::vector<uint64_t> cycle_counter;
 
-
 std::vector<uint64_t>& experiment(int task_size = 1000, int task_count = 1000) {
   
   // Reserve memory for counters in advance
-  cycle_counter.reserve(task_count * sizeof(decltype(cycle_counter)::value_type));
+  cycle_counter.resize(task_count, 0);
   
   // Execute task_count tasks of task_size  
   for (int i = 0; i < task_count; i++) {
     auto t1 = cycles();
     task(task_size);
     auto t2 = cycles();
-    cycle_counter.push_back(t2 - t1);
+    cycle_counter[i] = t2 - t1;
   }
 
   return cycle_counter;

--- a/jitter/exp1.cpp
+++ b/jitter/exp1.cpp
@@ -1,21 +1,9 @@
 #include <iostream>
 #include <vector>
 #include <cstdint>
-
+#include "exp.hpp"
 
 using namespace std;
-
-__attribute__((noinline))
-void task(int iterations) {
-  volatile int i = 0;
-  while(i < iterations) i++;
-}
-
-inline uint64_t cycles() noexcept {
-  uint32_t hi, lo;
-  asm("rdtscp" : "=a"(lo), "=d"(hi));
-  return ((uint64_t) lo) | ((uint64_t) hi) << 32;
-}
 
 std::vector<uint64_t> cycle_counter;
 

--- a/jitter/main-endless.cpp
+++ b/jitter/main-endless.cpp
@@ -4,6 +4,8 @@
 #include <ratio>
 #include <chrono>
 
+std::vector<uint64_t>& experiment(int tasksize = 1000, int task_count = 1000);
+
 void usage(const char* prog) {
   std::cout << "Usage: \n" << prog << " task_size log_threshold \n";
   exit(42);
@@ -23,7 +25,7 @@ int main(int argc, char** argv){
 
   auto t1 = std::chrono::high_resolution_clock::now();
 
-  int cycles = experiment(task_size, task_count);
+  auto cycles = experiment(task_size, log_threshold);
 
   auto t2 = std::chrono::high_resolution_clock::now();
 
@@ -32,6 +34,6 @@ int main(int argc, char** argv){
   for (auto i : cycles)
     std::cout << i << "\n";
 
-  std::cout << "# Completed " << task_count << " experiments "
+  std::cout << "# Completed " << log_threshold << " experiments "
             << " in " << time_span.count() << " seconds \n";
 }


### PR DESCRIPTION
- Move vector allocation out of the main loop
- Move tsc measurements to separate header file
- Make the endless experiments compile
- Smaller makefile fixes